### PR TITLE
Don't return $route if $route is #

### DIFF
--- a/src/Link.php
+++ b/src/Link.php
@@ -159,7 +159,7 @@ class Link
             $route = translate_route($this->getCleanRouteName(), null, $route->parameters);
 
             // If the route cannot be found as a translated route, we'll try to find a normal route
-            if (! is_null($route)) {
+            if (! is_null($route) && $route !== '#') {
                 return $route;
             }
         }


### PR DESCRIPTION
This fixes that we can still use normal routes if the translated_route() is not found