### PR TITLE
Added a way to ignore global scopes in the linkpicker

### DIFF
--- a/config/filament-link-picker.php
+++ b/config/filament-link-picker.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'ignored_global_scopes' => [
+        // \App\Models\Scopes\CustomScope::class,
+    ],
+];

--- a/docs/index.md
+++ b/docs/index.md
@@ -215,3 +215,39 @@ This package comes with a helper function called `lroute()`, with it you can rea
 ```
 
 If you have enabled the route to open in a new tab, the helper will automatically add the `target="_blank"` attribute to the link as well.
+
+## Config
+
+The config file contains the following:
+
+```php
+return [
+    'ignored_global_scopes' => [
+        // \App\Models\Scopes\CustomScope::class,
+    ],
+];
+```
+
+### ignored_global_scopes
+
+With this config, you can disable certain global scopes on your models. This is useful when you have a global scope that is not needed for the link picker.
+
+For example:
+```php
+return [
+    'ignored_global_scopes' => [
+        \App\Models\Scopes\OnlineScope::class,
+        'domains',
+    ],
+];
+```
+
+You can also use the `ignoredGlobalScopes` method on the `LinkPickerInput` field, like so:
+
+```php
+LinkPickerInput::make('link')
+    ->ignoredGlobalScopes([
+        \App\Models\Scopes\OnlineScope::class,
+        'domains',
+    ]),
+```

--- a/src/Filament/LinkPickerInput.php
+++ b/src/Filament/LinkPickerInput.php
@@ -2,6 +2,7 @@
 
 namespace Codedor\LinkPicker\Filament;
 
+use App\Models\Page;
 use Codedor\LinkPicker\Facades\LinkCollection;
 use Codedor\LinkPicker\Link;
 use Filament\Forms\Components\Actions\Action;
@@ -20,6 +21,7 @@ use ReflectionParameter;
 
 class LinkPickerInput extends Field
 {
+    use Traits\CanIgnoreGlobalScopes;
     protected string $view = 'filament-link-picker::filament.link-picker';
 
     protected function setUp(): void
@@ -190,7 +192,7 @@ class LinkPickerInput extends Field
                         ->label(Str::title($parameter->name))
                         ->required(! $parameter->allowsNull())
                         ->searchable()
-                        ->options($model::withoutGlobalScopes()->pluck(
+                        ->options($model::withoutGlobalScopes($this->getIgnoredGlobalScopes())->pluck(
                             $model::$linkPickerTitleField ?? 'id',
                             (new $model)->getKeyName(),
                         ));

--- a/src/Filament/LinkPickerInput.php
+++ b/src/Filament/LinkPickerInput.php
@@ -2,7 +2,6 @@
 
 namespace Codedor\LinkPicker\Filament;
 
-use App\Models\Page;
 use Codedor\LinkPicker\Facades\LinkCollection;
 use Codedor\LinkPicker\Link;
 use Filament\Forms\Components\Actions\Action;
@@ -22,6 +21,7 @@ use ReflectionParameter;
 class LinkPickerInput extends Field
 {
     use Traits\CanIgnoreGlobalScopes;
+
     protected string $view = 'filament-link-picker::filament.link-picker';
 
     protected function setUp(): void

--- a/src/Filament/Traits/CanIgnoreGlobalScopes.php
+++ b/src/Filament/Traits/CanIgnoreGlobalScopes.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Codedor\LinkPicker\Filament\Traits;
+
+use Closure;
+
+trait CanIgnoreGlobalScopes
+{
+    public array | Closure $ignoredGlobalScopes = [];
+
+    public function ignoredGlobalScopes(array | Closure $scopes)
+    {
+        $this->ignoredGlobalScopes = $scopes;
+
+        return $this;
+    }
+
+    public function getIgnoredGlobalScopes(): array
+    {
+        return [
+            ...config('filament-link-picker.ignored_global_scopes', []),
+            ...$this->evaluate($this->ignoredGlobalScopes),
+        ];
+    }
+}

--- a/src/Filament/Traits/CanIgnoreGlobalScopes.php
+++ b/src/Filament/Traits/CanIgnoreGlobalScopes.php
@@ -6,9 +6,9 @@ use Closure;
 
 trait CanIgnoreGlobalScopes
 {
-    public array | Closure $ignoredGlobalScopes = [];
+    public array|Closure $ignoredGlobalScopes = [];
 
-    public function ignoredGlobalScopes(array | Closure $scopes)
+    public function ignoredGlobalScopes(array|Closure $scopes)
     {
         $this->ignoredGlobalScopes = $scopes;
 

--- a/src/Providers/LinkPickerServiceProvider.php
+++ b/src/Providers/LinkPickerServiceProvider.php
@@ -19,6 +19,7 @@ class LinkPickerServiceProvider extends PackageServiceProvider
             ->name('filament-link-picker')
             ->setBasePath(__DIR__ . '/../')
             ->hasViews('filament-link-picker')
+            ->hasConfigFile('filament-link-picker')
             ->hasTranslations();
     }
 


### PR DESCRIPTION
Added a new trait and methods + a config file
When merged, don't forget to update the skeleton (see config file in HAP002).

To check: what happens if config is `[]`




