### PR TITLE
Add support for Laravel v11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,8 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.2, 8.3]
-        laravel: [10.*]
-        testbench: [8.*]
+        laravel: [10.*, 11.*]
         stability: [prefer-stable]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
@@ -38,7 +37,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea
-.phpunit.result.cache
+.phpunit.cache
 build
 composer.lock
 coverage

--- a/composer.json
+++ b/composer.json
@@ -9,17 +9,17 @@
     "homepage": "https://github.com/codedor/filament-link-picker",
     "license": "MIT",
     "require": {
-        "php": "^8.2",
-        "illuminate/contracts": "^10.0",
+        "php": "^8.2|^8.3",
+        "illuminate/contracts": "^10.0|^11.0",
         "spatie/laravel-package-tools": "^1.12",
         "filament/filament": "^3.0"
     },
     "require-dev": {
-        "codedor/laravel-translatable-routes": "^1.0",
+        "codedor/laravel-translatable-routes": "dev-feature/laravel-11",
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.0",
+        "nunomaduro/collision": "^7.0|^8.0",
         "larastan/larastan": "^2.0",
-        "orchestra/testbench": "^8.0",
+        "orchestra/testbench": "^8.0|^9.0",
         "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",
         "phpstan/extension-installer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "filament/filament": "^3.0"
     },
     "require-dev": {
-        "codedor/laravel-translatable-routes": "dev-feature/laravel-11",
+        "codedor/laravel-translatable-routes": "dev-feature/laravel-v11-support",
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.0|^8.0",
         "larastan/larastan": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "filament/filament": "^3.0"
     },
     "require-dev": {
-        "codedor/laravel-translatable-routes": "dev-feature/laravel-v11-support",
+        "codedor/laravel-translatable-routes": "^1.0",
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.0|^8.0",
         "larastan/larastan": "^2.0",

--- a/src/Link.php
+++ b/src/Link.php
@@ -24,8 +24,7 @@ class Link
     public function __construct(
         protected string $routeName,
         protected ?string $label = null,
-    ) {
-    }
+    ) {}
 
     public static function make(string $routeName, ?string $label = null): self
     {

--- a/tests/Fixtures/Forms/Livewire.php
+++ b/tests/Fixtures/Forms/Livewire.php
@@ -14,7 +14,7 @@ class Livewire extends Component implements HasForms
 
     public static function make(): static
     {
-        return new static();
+        return new static;
     }
 
     public function data($data): static

--- a/tests/Fixtures/Models/TestModel.php
+++ b/tests/Fixtures/Models/TestModel.php
@@ -4,6 +4,4 @@ namespace Codedor\LinkPicker\Tests\Fixtures\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
-class TestModel extends Model
-{
-}
+class TestModel extends Model {}


### PR DESCRIPTION
Requires https://github.com/codedor/laravel-translatable-routes/pull/24 to be merged and new release to be tagged