### PR TITLE
Fix anchor tags not showing up in the route (1.x backport)

### DIFF
--- a/src/Link.php
+++ b/src/Link.php
@@ -179,6 +179,7 @@ class Link
             return call_user_func($this->buildUsing, $this->parameters($parameters));
         }
 
+        $anchor = isset($parameters['anchor']) ? "#{$parameters['anchor']}" : null;
         $route = $this->resolveParameters($parameters);
 
         // If route binding fails
@@ -191,11 +192,11 @@ class Link
 
             // If the route cannot be found as a translated route, we'll try to find a normal route
             if (! is_null($route) && $route !== '#') {
-                return $route;
+                return "{$route}{$anchor}";
             }
         }
 
-        return route($this->routeName, $parameters);
+        return route($this->routeName, $parameters) . $anchor;
     }
 
     public function resolveParameters(array $parameters)


### PR DESCRIPTION
Backport of #34 to the `1.x` branch for older Filament (v3) versions.

Cherry-pick of 1e80385. Anchors picked in the link picker were silently dropped from the built URL because `resolveParameters()` strips the `anchor` parameter before route binding and `build()` never re-appended it. The anchor is now captured up front and appended to both the translated-route and `route()` fallback return paths.

Note: the `1.x` branch was newly created from `v1.7.0` (the latest 1.x tag) to serve as the maintenance branch for Filament v3.